### PR TITLE
ChipCompiler bugs

### DIFF
--- a/src/com/droidquest/chipstuff/ChipCompiler.java
+++ b/src/com/droidquest/chipstuff/ChipCompiler.java
@@ -48,22 +48,22 @@ public ChipCompiler(PrototypeChip pc, SmallChip sc)
 		    Device device = (Device) item;
 		    Gate gate=null;
 		    String type = item.getClass().toString();
-		    if (type.endsWith("ANDGate"))
+		    if (device instanceof com.droidquest.devices.ANDGate)
 		      gate = new Gate("AND");
-		    if (type.endsWith("ORGate"))
+		    if (device instanceof com.droidquest.devices.ORGate)
 		      gate = new Gate("OR");
-		    if (type.endsWith("NOTGate"))
+		    if (device instanceof com.droidquest.devices.NOTGate)
 		      gate = new Gate("NOT");
-		    if (type.endsWith("XORGate"))
+		    if (device instanceof com.droidquest.devices.XORGate)
 		      gate = new Gate("XOR");
-		    if (type.endsWith("FlipFlop"))
+		    if (device instanceof com.droidquest.devices.FlipFlop)
 		      {
 			 gate = new Gate("FF");
 			 gate.state = ((FlipFlop)device).state;
 		      }
-		    if (type.endsWith("Node"))
+		    if (device instanceof com.droidquest.devices.Node)
 		      gate = new Gate("NODE");
-		    if (type.endsWith("SmallChip"))
+		    if (device instanceof com.droidquest.devices.SmallChip)
 		      gate = new Gate((SmallChip)device);
 		    if (gate != null)
 		      {


### PR DESCRIPTION
In designing and burning a chip, I noticed that empty inputs would get wired to empty outputs, creating spurious behavior if (say) an OR gate is used as a delay, or a FlipFlop has an empty input. These will get wired to empty terminals on a node, because they share the "dummy" signal. My first patch fixes this issue by not allowing the dummy signal to be connected during the node-stripping phase of ChipCompiler.

The second bug is not currently causing problems, but it seemed safer to fix it. Checking type.endsWith('ORGate') will also match XORGate, causing an extra gate to get created. Since the XOR check comes after the OR check, this doesn't affect the final result, but if the code were re-ordered, it would cause issues. I changed the string comparisons to use instanceof.

Thanks for making this port. I played Think Quick as a kid, and had to try Robot Odyssey/Droid Quest after seeing the Slate article. Cheers!
