### PR TITLE
Make DroidQuest be available on Ubuntu14.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@ DroidQuest
 
 A Java recreation of the classic game Robot Odyssey I
 
+Compile command:
+	mvn compile
+
+Run the game:
+	./start_game.sh
 
 Copyright (c) 2000 Thomas Foote
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ DroidQuest
 A Java recreation of the classic game Robot Odyssey I
 
 Compile command:
+
 	mvn compile
 
 Run the game:
+
 	./start_game.sh
 
 Copyright (c) 2000 Thomas Foote

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,17 @@
 
     <build>
         <sourceDirectory>src</sourceDirectory>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.3</version>
+                <configuration>
+                    <source>5</source>
+                    <target>5</target>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 
     <dependencies>

--- a/start_game.sh
+++ b/start_game.sh
@@ -1,0 +1,1 @@
+mvn exec:java -Dexec.mainClass=com.droidquest.DQ


### PR DESCRIPTION
I cloned it and played a while, this game is awesome.

Although it took me half of hour to figure out how to build the project, it still makes everything so simple to play classic DOS game on my Ubuntu laptop.

While building project with Maven, I encountered an error which told me to use '-source 5' option, so I added some lines in pom.xml. This version worked perfect on my latest Ubuntu 14.04 system now.