### PR TITLE
Fix for issue 26 (level 3 gatekeeper), and a div-by-0 bug in level 4 trash collector

### DIFF
--- a/src/com/droidquest/items/GateKeeper.java
+++ b/src/com/droidquest/items/GateKeeper.java
@@ -13,7 +13,10 @@ public class GateKeeper extends Item {
 // 1= Go to trash, delete F-12, delete StormShield
 
     private int goToX = 2 * 28 + 14;
-    private int goToY = 8 * 32;
+    // This was 8 * 32, but the GateKeeper is unable to go past
+    // 8 * 32 - 6, so it would never reach the target the player couldn't
+    // proceed past this challenge.
+    private int goToY = 8 * 32 - 6;
 
     public GateKeeper(int X, int Y, Room r) {
         x = X;
@@ -63,6 +66,11 @@ public class GateKeeper extends Item {
     }
 
     public void Animate() {
+        // hack: check if goToY is the expected value. It is essentially
+        // a constant, but it was changed in the code and older saved games
+        // may bring in an older value when the object is deserialized.
+        if (goToY != 8 * 32 - 6) goToY = 8 * 32 - 6;
+        
         if (behavior == 1) {
             if (x != goToX || y != goToY) {
                 if (x != goToX) {

--- a/src/com/droidquest/items/TrashCollector.java
+++ b/src/com/droidquest/items/TrashCollector.java
@@ -196,8 +196,8 @@ public class TrashCollector extends Item {
                 if (room != gotoRoom) {
                     moveDown(4);
                     if (x != 266) {
-                        int diff = Math.abs(266 - y);
-                        int dir = diff / (266 - y);
+                        int diff = Math.abs(266 - x);
+                        int dir = diff / (266 - x);
                         if (diff > 4) {
                             diff = 4;
                         }


### PR DESCRIPTION
For the gatekeeper, this changes its target coordinates, because his target was just outside his range of movement.

The trash collector fix is just correcting a simple typo.

